### PR TITLE
fixes

### DIFF
--- a/Sources/JSONSchema.swift
+++ b/Sources/JSONSchema.swift
@@ -199,7 +199,7 @@ func validators(_ root: Schema) -> (_ schema: [String:Any]) -> [Validator] {
           return flatten(document.map(itemsValidators))
         }
 
-        return .Valid
+        return .valid
       }
 
       validators.append(validateItems)
@@ -236,7 +236,7 @@ func validators(_ root: Schema) -> (_ schema: [String:Any]) -> [Validator] {
           return flatten(results)
         }
 
-        return .Valid
+        return .valid
       }
 
       validators.append(validateItems)
@@ -292,7 +292,7 @@ func validators(_ root: Schema) -> (_ schema: [String:Any]) -> [Validator] {
           }
         }
 
-        return .Valid
+        return .valid
       }
     }
 
@@ -304,12 +304,12 @@ func validators(_ root: Schema) -> (_ schema: [String:Any]) -> [Validator] {
               if value[dependency] == nil {
                 return .invalid(["'\(key)' is missing it's dependency of '\(dependency)'"])
               }
-              return .Valid
+              return .valid
             })
           }
         }
 
-        return .Valid
+        return .valid
       }
     }
 

--- a/Sources/Validators.swift
+++ b/Sources/Validators.swift
@@ -10,12 +10,12 @@ import Foundation
 
 
 public enum ValidationResult {
-  case Valid
+  case valid
   case invalid([String])
 
   public var valid: Bool {
     switch self {
-    case .Valid:
+    case .valid:
       return true
     case .invalid:
       return false
@@ -24,7 +24,7 @@ public enum ValidationResult {
 
   public var errors:[String]? {
     switch self {
-    case .Valid:
+    case .valid:
       return nil
     case .invalid(let errors):
       return errors
@@ -50,12 +50,12 @@ func flatten(_ results:[ValidationResult]) -> ValidationResult {
     return .invalid(errors)
   }
 
-  return .Valid
+  return .valid
 }
 
 /// Creates a Validator which always returns an valid result
 func validValidation(_ value:Any) -> ValidationResult {
-  return .Valid
+  return .valid
 }
 
 /// Creates a Validator which always returns an invalid result with the given error
@@ -74,36 +74,36 @@ func validateType(_ type: String) -> (_ value: Any) -> ValidationResult {
     case "integer":
       if let number = value as? NSNumber {
         if !CFNumberIsFloatType(number) && CFGetTypeID(number) != CFBooleanGetTypeID() {
-          return .Valid
+          return .valid
         }
       }
     case "number":
       if let number = value as? NSNumber {
         if CFGetTypeID(number) != CFBooleanGetTypeID() {
-          return .Valid
+          return .valid
         }
       }
     case "string":
       if value is String {
-        return .Valid
+        return .valid
       }
     case "object":
       if value is NSDictionary {
-        return .Valid
+        return .valid
       }
     case "array":
       if value is NSArray {
-        return .Valid
+        return .valid
       }
     case "boolean":
       if let number = value as? NSNumber {
         if CFGetTypeID(number) == CFBooleanGetTypeID() {
-          return .Valid
+          return .valid
         }
       }
     case "null":
       if value is NSNull {
-        return .Valid
+        return .valid
       }
     default:
       break
@@ -136,7 +136,7 @@ func anyOf(_ validators:[Validator], error:String? = nil) -> (_ value: Any) -> V
     for validator in validators {
       let result = validator(value)
       if result.valid {
-        return .Valid
+        return .valid
       }
     }
 
@@ -154,7 +154,7 @@ func oneOf(_ validators: [Validator]) -> (_ value: Any) -> ValidationResult {
     let validValidators = results.filter { $0.valid }.count
 
     if validValidators == 1 {
-      return .Valid
+      return .valid
     }
 
     return .invalid(["\(validValidators) validates instead `oneOf`."])
@@ -168,7 +168,7 @@ func not(_ validator: @escaping Validator) -> (_ value: Any) -> ValidationResult
       return .invalid(["'\(value)' does not match 'not' validation."])
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -181,7 +181,7 @@ func allOf(_ validators: [Validator]) -> (_ value: Any) -> ValidationResult {
 func validateEnum(_ values: [Any]) -> (_ value: Any) -> ValidationResult {
   return { value in
     if (values as! [NSObject]).contains(value as! NSObject) {
-      return .Valid
+      return .valid
     }
 
     return .invalid(["'\(value)' is not a valid enumeration value of '\(values)'"])
@@ -198,7 +198,7 @@ func validateLength(_ comparitor: @escaping ((Int, Int) -> (Bool)), length: Int,
       }
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -216,7 +216,7 @@ func validatePattern(_ pattern: String) -> (_ value: Any) -> ValidationResult {
       }
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -233,7 +233,7 @@ func validateMultipleOf(_ number: Double) -> (_ value: Any) -> ValidationResult 
       }
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -251,7 +251,7 @@ func validateNumericLength(_ length: Double, comparitor: @escaping ((Double, Dou
       }
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -265,7 +265,7 @@ func validateArrayLength(_ rhs: Int, comparitor: @escaping ((Int, Int) -> Bool),
       }
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -286,13 +286,13 @@ func validateUniqueItems(_ value: Any) -> ValidationResult {
     let delta = (hasTrueAndOne ? 1 : 0) + (hasFalseAndZero ? 1 : 0)
 
     if (NSSet(array: value).count + delta) == value.count {
-      return .Valid
+      return .valid
     }
 
     return .invalid(["\(value) does not have unique items"])
   }
 
-  return .Valid
+  return .valid
 }
 
 // MARK: Object
@@ -305,7 +305,7 @@ func validatePropertiesLength(_ length: Int, comparitor: @escaping ((Int, Int) -
       }
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -319,13 +319,13 @@ func validateRequired(_ required: [String]) -> (_ value: Any)  -> ValidationResu
       }
       
       if missingKeys.isEmpty {
-        return .Valid
+        return .valid
       }
 
       return .invalid(["Required properties are missing '\(missingKeys)'"])
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -369,7 +369,7 @@ func validateProperties(_ properties: [String:Validator]?, patternProperties: [S
       return flatten(results)
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -407,25 +407,25 @@ func validateIPv4(_ value:Any) -> ValidationResult {
   if let ipv4 = value as? String {
     if let expression = try? NSRegularExpression(pattern: "^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", options: NSRegularExpression.Options(rawValue: 0)) {
       if expression.matches(in: ipv4, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: NSMakeRange(0, ipv4.characters.count)).count == 1 {
-        return .Valid
+        return .valid
       }
     }
 
     return .invalid(["'\(ipv4)' is not valid IPv4 address."])
   }
 
-  return .Valid
+  return .valid
 }
 
 func validateIPv6(_ value:Any) -> ValidationResult {
   if let ipv6 = value as? String {
     var buf = UnsafeMutablePointer<Int8>.allocate(capacity: Int(INET6_ADDRSTRLEN))
     if inet_pton(AF_INET6, ipv6, &buf) == 1 {
-      return .Valid
+      return .valid
     }
 
     return .invalid(["'\(ipv6)' is not valid IPv6 address."])
   }
 
-  return .Valid
+  return .valid
 }

--- a/Sources/Validators.swift
+++ b/Sources/Validators.swift
@@ -312,11 +312,17 @@ func validatePropertiesLength(_ length: Int, comparitor: @escaping ((Int, Int) -
 func validateRequired(_ required: [String]) -> (_ value: Any)  -> ValidationResult {
   return { value in
     if let value = value as? [String:Any] {
-      if (required.filter { r in !value.keys.contains(r) }.count == 0) {
+      var missingKeys = [String]()
+      
+      for requiredKey in required where !value.keys.contains(requiredKey) {
+        missingKeys.append(requiredKey)
+      }
+      
+      if missingKeys.isEmpty {
         return .Valid
       }
 
-      return .invalid(["Required properties are missing '\(required)'"])
+      return .invalid(["Required properties are missing '\(missingKeys)'"])
     }
 
     return .Valid

--- a/Tests/JSONSchemaCases.swift
+++ b/Tests/JSONSchemaCases.swift
@@ -107,7 +107,7 @@ func makeAssertions(_ c:Case) -> ([Assertion]) {
     return ("\(c.description) \(test.description)", {
       let result = validate(test.data, schema: c.schema)
       switch result {
-      case .Valid:
+      case .valid:
         XCTAssertEqual(result.valid, test.value, "Result is valid")
       case .invalid(let errors):
         XCTAssertEqual(result.valid, test.value, "Failed validation: \(errors)")

--- a/Tests/JSONSchemaTests.swift
+++ b/Tests/JSONSchemaTests.swift
@@ -56,4 +56,42 @@ class JSONSchemaTests: XCTestCase {
     XCTAssertTrue(schema.validate(["name": "Eggs", "price": 34.99]).valid)
     XCTAssertFalse(schema.validate(["price": 34.99]).valid)
   }
+
+  /// Tests that the error output provides only the keys that were missing instead of all required keys.
+  func testInvalidSchema_returnsErrorForMissingRequiredProperty() {
+    let schema = Schema([
+      "type": "object",
+      "properties": [
+        "name": ["type": "string"],
+        "price": ["type": "number"],
+        "bar": ["type": "string"]
+      ],
+      "required": ["name", "price", "bar"],
+    ])
+    
+    let result: ValidationResult = schema.validate(["name": "foo", "bar": "foo"])
+    
+    XCTAssertFalse(result.valid)
+    XCTAssertNotNil(result.errors)
+    XCTAssertEqual(result.errors![0], "Required properties are missing '[\"price\"]'")
+    XCTAssertNotEqual(result.errors![0], "Required properties are missing '[\"name\", \"price\", \"bar\"]'")
+  }
+  
+  func testInvalidSchema_returnsErrorForMissingRequiredProperties() {
+    let schema = Schema([
+      "type": "object",
+      "properties": [
+        "name": ["type": "string"],
+        "price": ["type": "number"],
+        "bar": ["type": "string"]
+      ],
+      "required": ["name", "price", "bar"],
+      ])
+    
+    let result: ValidationResult = schema.validate(["name": "foo"])
+    
+    XCTAssertFalse(result.valid)
+    XCTAssertNotNil(result.errors)
+    XCTAssertEqual(result.errors![0], "Required properties are missing '[\"price\", \"bar\"]'")
+  }
 }


### PR DESCRIPTION
- update project settings for Xcode 8.3
- rename `ValidationResult` enum for Swift 3
- update error message to specify which required properties are missing when validation fails
- add unit tests to cover new error message behavior